### PR TITLE
Add root URL for offset endpoint

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -4,5 +4,6 @@ from django.urls import path
 from cad.views import offset_view
 
 urlpatterns = [
+    path("", offset_view, name="offset_root"),
     path("offset", offset_view, name="offset"),
 ]


### PR DESCRIPTION
## Summary
- add a root URL pattern that serves the offset view so the homepage no longer 404s

## Testing
- python manage.py check *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68e597917518832abf9c24726bdf6ce6