### PR TITLE
Allow GET requests on offset endpoint

### DIFF
--- a/cad/views.py
+++ b/cad/views.py
@@ -102,9 +102,17 @@ def offset_points(points: Iterable[PointData], offset: float) -> List[Tuple[floa
 
 
 @csrf_exempt
-@require_http_methods(["POST"])
+@require_http_methods(["GET", "POST"])
 def offset_view(request: HttpRequest) -> JsonResponse:
     """Handle CAD file uploads and return offset coordinates."""
+
+    if request.method == "GET":
+        return JsonResponse(
+            {
+                "message": "POST a CAD file using the 'file' field and an 'offset' value to compute offset points.",
+                "required_fields": {"file": "CAD file upload", "offset": "float"},
+            }
+        )
 
     uploaded_file = request.FILES.get("file")
     if uploaded_file is None:


### PR DESCRIPTION
## Summary
- allow the offset endpoint to respond to GET requests with usage guidance
- keep POST handling intact for CAD offset calculations

## Testing
- python manage.py test *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68e598d063e0832a9f4f4456a7a01d79